### PR TITLE
Improve `Option` decoding

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,7 @@ pub enum Error {
     MissingKey,
     MissingValues,
     MissingValue,
+    ForbiddenTopLevelOption,
     RemoveKeyFailed(String),
     Message(String),
     #[cfg(feature = "from_str")]


### PR DESCRIPTION
The library wasn't gracefully handling `Option`s due to a missing implementation of `deserialize_option`.

As shown in the examples, `Option`s are now supported on the fields of top-level structs, but not elsewhere.