### PR TITLE
Disallow extra query keys

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,7 @@ pub enum Error {
     MissingValues,
     MissingValue,
     ForbiddenTopLevelOption,
+    InvalidExtraKey(String),
     RemoveKeyFailed(String),
     Message(String),
     #[cfg(feature = "from_str")]


### PR DESCRIPTION
Rather than requiring all query structs to be declared with `serde(deny_unknown_fields)`, this PR makes it so that the deserializer always errors in case of extra keys not read by the visitor.

We may want to relax or remove this restriction in future.