### PR TITLE
Release v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_array_query"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Serde deserialization format for HTTP query string arrays"
 license = "Apache-2.0"


### PR DESCRIPTION
New release for https://github.com/sigp/serde_array_query/pull/8.